### PR TITLE
Add editing endpoints and client controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,12 @@ npm run dev
 ```
 
 서버는 기본 3001번 포트에서 실행되고, 클라이언트 개발 서버는 5173번 포트에서 동작하며 API 요청은 프록시를 통해 서버로 전달됩니다.
+
+## 추가 API
+
+- `GET /api/health`: 서버 상태를 확인하는 헬스 체크 엔드포인트입니다.
+- `GET /api/maps`: 업로드하여 생성된 마인드맵 ID 목록을 반환합니다.
+- `GET /api/maps/:id`: 특정 ID의 마인드맵 JSON을 조회합니다.
+- `POST /api/maps/:id/add`: 지정한 경로에 자식 노드를 추가합니다. `path` 배열과 `title`을 JSON으로 전달합니다.
+- `POST /api/maps/:id/remove`: `path` 배열로 특정 노드를 삭제합니다.
+- `POST /api/maps/:id/expand`: `path`에 해당하는 노드를 LLM을 이용해 더 세부 구조로 확장합니다.

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,10 +1,50 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+
+function MindMapNode({ node, path, onAdd, onDelete, onExpand }) {
+  const label = node.title || node.name || node.key || 'Node';
+  return (
+    <li>
+      {label}{' '}
+      {onAdd && <button onClick={() => onAdd(path)}>Add</button>}{' '}
+      {onDelete && <button onClick={() => onDelete(path)}>Delete</button>}{' '}
+      {onExpand && <button onClick={() => onExpand(path)}>Expand</button>}
+      {Array.isArray(node.children) && node.children.length > 0 && (
+        <ul>
+          {node.children.map((child, idx) => (
+            <MindMapNode
+              key={idx}
+              node={child}
+              path={[...path, idx]}
+              onAdd={onAdd}
+              onDelete={onDelete}
+              onExpand={onExpand}
+            />
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+}
 
 function App() {
   const [file, setFile] = useState(null);
   const [tree, setTree] = useState(null);
+  const [mapId, setMapId] = useState('');
+  const [maps, setMaps] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+
+  const loadMaps = async () => {
+    const res = await fetch('/api/maps');
+    if (res.ok) {
+      const data = await res.json();
+      setMaps(data);
+    }
+  };
+
+  useEffect(() => {
+    loadMaps();
+  }, []);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -18,10 +58,52 @@ function App() {
       if (!res.ok) throw new Error('Upload failed');
       const data = await res.json();
       setTree(data.tree);
+      setMapId(data.id);
+      await loadMaps();
     } catch (err) {
       setError(err.message);
     } finally {
       setLoading(false);
+    }
+  };
+
+  const addChild = async path => {
+    const title = prompt('Child title');
+    if (!title || !mapId) return;
+    const res = await fetch(`/api/maps/${mapId}/add`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path, title })
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setTree({ ...data });
+    }
+  };
+
+  const deleteNode = async path => {
+    if (!mapId || !confirm('Delete node?')) return;
+    const res = await fetch(`/api/maps/${mapId}/remove`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path })
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setTree({ ...data });
+    }
+  };
+
+  const expandNode = async path => {
+    if (!mapId) return;
+    const res = await fetch(`/api/maps/${mapId}/expand`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path })
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setTree({ ...data });
     }
   };
 
@@ -34,7 +116,33 @@ function App() {
       </form>
       {loading && <p>Processing...</p>}
       {error && <p style={{ color: 'red' }}>{error}</p>}
-      {tree && <pre>{JSON.stringify(tree, null, 2)}</pre>}
+      {tree && (
+        <div>
+          <h2>Mind Map</h2>
+          <ul>
+            <MindMapNode
+              node={tree}
+              path={[]}
+              onAdd={addChild}
+              onDelete={deleteNode}
+              onExpand={expandNode}
+            />
+          </ul>
+          <p>ID: {mapId}</p>
+          <h3>Raw JSON</h3>
+          <pre>{JSON.stringify(tree, null, 2)}</pre>
+        </div>
+      )}
+      {maps.length > 0 && (
+        <div>
+          <h2>Saved Maps</h2>
+          <ul>
+            {maps.map(m => (
+              <li key={m.id}>{m.id}</li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }

--- a/server/index.js
+++ b/server/index.js
@@ -5,9 +5,61 @@ import fs from 'fs';
 import { v4 as uuidv4 } from 'uuid';
 
 const app = express();
+app.use(express.json());
 const upload = multer({ dest: 'uploads/' });
 const PORT = process.env.PORT || 3001;
 const UPSTAGE_API_KEY = process.env.UPSTAGE_API_KEY;
+// 업로드된 마인드맵을 메모리에 저장하기 위한 간단한 배열
+const maps = [];
+
+function getNodeByPath(tree, path) {
+  let node = tree;
+  for (const idx of path) {
+    if (!node.children || !node.children[idx]) return null;
+    node = node.children[idx];
+  }
+  return node;
+}
+
+function removeNodeByPath(tree, path) {
+  if (path.length === 0) return false;
+  const last = path[path.length - 1];
+  const parentPath = path.slice(0, -1);
+  const parent = getNodeByPath(tree, parentPath);
+  if (!parent || !parent.children || !parent.children[last]) return false;
+  parent.children.splice(last, 1);
+  return true;
+}
+
+function addChildByPath(tree, path, child) {
+  const parent = getNodeByPath(tree, path);
+  if (!parent) return false;
+  if (!parent.children) parent.children = [];
+  parent.children.push(child);
+  return true;
+}
+
+async function structuredOutput(text) {
+  if (!UPSTAGE_API_KEY) {
+    throw new Error('UPSTAGE_API_KEY not configured');
+  }
+  const res = await fetch('https://api.upstage.ai/v1/structured-output', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${UPSTAGE_API_KEY}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ text })
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Upstage structured request failed: ${body}`);
+  }
+
+  const data = await res.json();
+  return data.text || text;
+}
 
 async function parseDocument(filePath, mime) {
   if (!UPSTAGE_API_KEY) {
@@ -61,14 +113,79 @@ app.post('/api/upload', upload.single('file'), async (req, res) => {
   const { file } = req;
   try {
     const text = await parseDocument(file.path, file.mimetype);
-    const tree = await buildMindMap(text);
-    res.json({ tree, id: uuidv4() });
+    const formatted = await structuredOutput(text);
+    const tree = await buildMindMap(formatted);
+    const id = uuidv4();
+    maps.push({ id, tree, text, formatted });
+    res.json({ tree, id });
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: err.message });
   } finally {
     fs.unlink(file.path, () => {});
   }
+});
+
+// 저장된 마인드맵 목록 반환
+app.get('/api/maps', (req, res) => {
+  res.json(maps.map(({ id }) => ({ id })));
+});
+
+// 특정 ID의 마인드맵 조회
+app.get('/api/maps/:id', (req, res) => {
+  const map = maps.find(m => m.id === req.params.id);
+  if (!map) {
+    return res.status(404).json({ error: 'Not found' });
+  }
+  res.json(map);
+});
+
+// 노드 삭제
+app.post('/api/maps/:id/remove', (req, res) => {
+  const map = maps.find(m => m.id === req.params.id);
+  if (!map) return res.status(404).json({ error: 'Not found' });
+  const { path } = req.body;
+  if (!Array.isArray(path)) return res.status(400).json({ error: 'Invalid path' });
+  const ok = removeNodeByPath(map.tree, path);
+  if (!ok) return res.status(400).json({ error: 'Remove failed' });
+  res.json(map.tree);
+});
+
+// 자식 노드 추가
+app.post('/api/maps/:id/add', (req, res) => {
+  const map = maps.find(m => m.id === req.params.id);
+  if (!map) return res.status(404).json({ error: 'Not found' });
+  const { path, title } = req.body;
+  if (!Array.isArray(path) || typeof title !== 'string') {
+    return res.status(400).json({ error: 'Invalid body' });
+  }
+  const child = { title };
+  const ok = addChildByPath(map.tree, path, child);
+  if (!ok) return res.status(400).json({ error: 'Add failed' });
+  res.json(map.tree);
+});
+
+// LLM 기반 확장
+app.post('/api/maps/:id/expand', async (req, res) => {
+  const map = maps.find(m => m.id === req.params.id);
+  if (!map) return res.status(404).json({ error: 'Not found' });
+  const { path } = req.body;
+  if (!Array.isArray(path)) return res.status(400).json({ error: 'Invalid path' });
+  const node = getNodeByPath(map.tree, path);
+  if (!node) return res.status(400).json({ error: 'Node not found' });
+  try {
+    const prompt = `${map.formatted}\n\n위 내용 중 '${node.title || node.name || node.key}' 항목을 더 세부적인 마인드맵으로 확장해줘.`;
+    const newTree = await buildMindMap(prompt);
+    node.children = newTree.children || [];
+    res.json(map.tree);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/api/health', (req, res) => {
+  res.json({ status: 'ok' });
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- allow editing of mind map nodes on the server
- provide buttons to add, delete, or expand nodes on the client
- document new editing API routes

## Testing
- `npm test` *(fails: could not find package.json)*
- `cd server && npm test` *(fails: missing script)*
- `cd client && npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68499c9394e4832589add3b426078643