### PR TITLE
Add text upload support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VisualMind MVP
 
-VisualMind은 문서나 이미지로부터 자동으로 마인드맵을 생성하는 웹 애플리케이션입니다. React 기반 프런트엔드와 Node.js 백엔드로 구성되어 있으며, Upstage의 OCR/Parser와 Solar Pro LLM을 활용해 업로드된 파일을 분석하고 2단계 깊이의 트리 구조를 생성합니다.
+VisualMind은 문서나 이미지뿐 아니라 사용자가 직접 입력한 텍스트로부터도 자동으로 마인드맵을 생성하는 웹 애플리케이션입니다. React 기반 프런트엔드와 Node.js 백엔드로 구성되어 있으며, Upstage의 OCR/Parser와 Solar Pro LLM을 활용해 업로드된 파일이나 텍스트를 분석하고 2단계 깊이의 트리 구조를 생성합니다.
 
 ## 주요 구성 요소
 
@@ -41,6 +41,7 @@ npm run dev
 - `GET /api/health`: 서버 상태를 확인하는 헬스 체크 엔드포인트입니다.
 - `GET /api/maps`: 업로드하여 생성된 마인드맵 ID 목록을 반환합니다.
 - `GET /api/maps/:id`: 특정 ID의 마인드맵 JSON을 조회합니다.
+- `POST /api/text`: 텍스트를 직접 전달하여 마인드맵을 생성합니다. `{ text }`를 JSON으로 보냅니다.
 - `POST /api/maps/:id/add`: 지정한 경로에 자식 노드를 추가합니다. `path` 배열과 `title`을 JSON으로 전달합니다.
 - `POST /api/maps/:id/remove`: `path` 배열로 특정 노드를 삭제합니다.
 - `POST /api/maps/:id/expand`: `path`에 해당하는 노드를 LLM을 이용해 더 세부 구조로 확장합니다.

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -28,6 +28,7 @@ function MindMapNode({ node, path, onAdd, onDelete, onExpand }) {
 
 function App() {
   const [file, setFile] = useState(null);
+  const [text, setText] = useState('');
   const [tree, setTree] = useState(null);
   const [mapId, setMapId] = useState('');
   const [maps, setMaps] = useState([]);
@@ -48,13 +49,25 @@ function App() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    if (!file) return;
-    const formData = new FormData();
-    formData.append('file', file);
     setLoading(true);
     setError('');
     try {
-      const res = await fetch('/api/upload', { method: 'POST', body: formData });
+      let res;
+      if (file) {
+        const formData = new FormData();
+        formData.append('file', file);
+        res = await fetch('/api/upload', { method: 'POST', body: formData });
+      } else if (text.trim()) {
+        res = await fetch('/api/text', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ text })
+        });
+      } else {
+        setError('No file or text provided');
+        setLoading(false);
+        return;
+      }
       if (!res.ok) throw new Error('Upload failed');
       const data = await res.json();
       setTree(data.tree);
@@ -111,8 +124,19 @@ function App() {
     <div style={{ padding: '2rem' }}>
       <h1>VisualMind MVP</h1>
       <form onSubmit={handleSubmit}>
-        <input type="file" onChange={e => setFile(e.target.files[0])} />
-        <button type="submit">Upload</button>
+        <div style={{ marginBottom: '0.5rem' }}>
+          <input type="file" onChange={e => setFile(e.target.files[0])} />
+        </div>
+        <div style={{ marginBottom: '0.5rem' }}>
+          <textarea
+            placeholder="또는 텍스트를 입력하세요"
+            rows="5"
+            style={{ width: '100%' }}
+            value={text}
+            onChange={e => setText(e.target.value)}
+          />
+        </div>
+        <button type="submit">Submit</button>
       </form>
       {loading && <p>Processing...</p>}
       {error && <p style={{ color: 'red' }}>{error}</p>}

--- a/server/index.js
+++ b/server/index.js
@@ -126,6 +126,24 @@ app.post('/api/upload', upload.single('file'), async (req, res) => {
   }
 });
 
+// 텍스트 직접 입력 처리
+app.post('/api/text', async (req, res) => {
+  const { text } = req.body;
+  if (typeof text !== 'string' || !text.trim()) {
+    return res.status(400).json({ error: 'Text required' });
+  }
+  try {
+    const formatted = await structuredOutput(text);
+    const tree = await buildMindMap(formatted);
+    const id = uuidv4();
+    maps.push({ id, tree, text, formatted });
+    res.json({ tree, id });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // 저장된 마인드맵 목록 반환
 app.get('/api/maps', (req, res) => {
   res.json(maps.map(({ id }) => ({ id })));


### PR DESCRIPTION
## Summary
- allow sending raw text to the backend
- show text area on front-end
- document `/api/text` endpoint

## Testing
- `npm test` (fails: missing script)
- `npm run build` in client
- `npm test` in server (fails: missing script)

------
https://chatgpt.com/codex/tasks/task_e_684a104e84e8832599a4243540884782