### PR TITLE
Implement admin RBAC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 uploads
 dist
 .env
+server/visualmind.db

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -6,10 +6,10 @@ This repository currently implements only basic MVP features. To prepare for pro
 - [x] Persistent database for maps and users
 - [ ] Cloud file storage (e.g. S3 or Firebase Storage)
 - [x] Rate limiting
-- [ ] Usage quota per user
+- [x] Usage quota per user
 - [x] Caching of LLM/OCR results
-- [ ] Virus scanning for uploaded files
-- [ ] Role based access control
+- [x] Virus scanning for uploaded files
+- [x] Role based access control
 - [ ] Structured logging and monitoring (basic request logs only)
 - [ ] CI/CD automation
 - [ ] Billing and subscription management

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ VisualMind은 문서나 이미지뿐 아니라 사용자가 직접 입력한 텍
 6. 결과 JSON을 프런트엔드로 반환하여 화면에 표시하거나 저장에 활용할 수 있습니다.
 
 API 키는 `UPSTAGE_API_KEY` 환경 변수로 주입하며, 실 서비스에서는 GitHub Actions 등에서 비밀 값으로 관리합니다.
+바이러스 검사를 위해 `CLAMAV_HOST`와 `CLAMAV_PORT` 환경 변수를 설정하면 업로드된 파일을 ClamAV 서버로 스캔합니다.
+관리자 계정은 `ADMIN_UIDS` 환경 변수(콤마 구분 UID 목록)로 지정하여 역할 기반 접근 제어를 활성화할 수 있습니다.
 
 ## 실행 방법
 
@@ -41,10 +43,14 @@ cd ../client && npm run build
 서버는 기본 3001번 포트에서 실행되고, 클라이언트 개발 서버는 5173번 포트에서 동작하며 API 요청은 프록시를 통해 서버로 전달됩니다.
 
 ## 추가 API
+- `POST /api/upload`: 파일을 업로드하여 마인드맵을 생성합니다. `file` 필드를 multipart 형식으로 전송합니다.
 
 - `GET /api/health`: 서버 상태를 확인하는 헬스 체크 엔드포인트입니다.
+- `GET /api/usage`: 오늘 사용량과 할당량을 반환합니다.
 - `GET /api/maps`: 업로드하여 생성된 마인드맵 ID 목록을 반환합니다.
 - `GET /api/maps/:id`: 특정 ID의 마인드맵 JSON을 조회합니다.
+- `DELETE /api/maps/:id`: 지정한 마인드맵을 삭제합니다.
+- `GET /api/admin/maps`: 관리자 전용, 모든 사용자의 마인드맵 ID와 소유자를 조회합니다.
 - `POST /api/text`: 텍스트를 직접 전달하여 마인드맵을 생성합니다. `{ text }`를 JSON으로 보냅니다.
 - `POST /api/maps/:id/add`: 지정한 경로에 자식 노드를 추가합니다. `path` 배열과 `title`을 JSON으로 전달합니다.
 - `POST /api/maps/:id/remove`: `path` 배열로 특정 노드를 삭제합니다.

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "better-sqlite3": "^9.1.0",
+        "clamav.js": "^0.12.0",
         "express": "^4.18.2",
         "express-rate-limit": "^6.7.0",
         "firebase-admin": "^11.10.1",
@@ -965,6 +966,12 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
+    },
+    "node_modules/clamav.js": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/clamav.js/-/clamav.js-0.12.0.tgz",
+      "integrity": "sha512-IoPwy6rzivi9PGtRR9GvnXmfCLbMi+WX46j5S/SFG3tniIqesxq6976su7jGmhSu8FLp8TUC/ZE604KxELacWg==",
+      "license": "MIT"
     },
     "node_modules/cliui": {
       "version": "8.0.1",

--- a/server/package.json
+++ b/server/package.json
@@ -16,6 +16,7 @@
     "better-sqlite3": "^9.1.0",
     "express-rate-limit": "^6.7.0",
     "node-cache": "^5.1.2",
-    "morgan": "^1.10.0"
+    "morgan": "^1.10.0",
+    "clamav.js": "^0.12.0"
   }
 }


### PR DESCRIPTION
## Summary
- introduce an `ADMIN_UIDS` env var for specifying admin accounts
- add middleware for role-based access control and admin API route
- allow admin users to manage any map
- document new env var and admin API
- mark role-based access control complete in the checklist

## Testing
- `npm install` and `npm start` in `server`
- `npm install` and `npm run build` in `client`


------
https://chatgpt.com/codex/tasks/task_e_684a49eb9d348325830c4ccde6436fd4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added admin-level access, allowing administrators to view and manage all users' mindmaps.
  - Introduced virus scanning for uploaded files to enhance security.
  - Implemented daily usage tracking and quota reporting for users.
  - Enabled users to delete their own mindmaps directly from the interface.

- **Documentation**
  - Updated README with new environment variables and API endpoints.
  - Marked checklist items for usage quota, virus scanning, and role-based access control as complete.

- **Chores**
  - Updated dependencies to include virus scanning support.
  - Adjusted repository settings to ignore database files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->