### PR TITLE
Add Cloudflare Worker example

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,16 @@ cd ../client && npm run build
 - `POST /api/rum`: 브라우저 Web Vitals 지표를 수집합니다.
 - `GET /api/review`: 오늘 복습이 필요한 노드 목록을 반환합니다.
 - `POST /api/review`: 노드 복습 결과를 기록하여 다음 복습 날짜를 계산합니다.
+
+## Cloudflare Worker Deployment
+
+`cf-worker` 디렉터리에는 [Hono](https://hono.dev) 기반의 간단한 Cloudflare Worker 예제가 포함되어 있습니다.
+업로드 파일을 R2 버킷에 저장하고, 마인드맵 JSON은 D1 데이터베이스에 보관합니다.
+
+```
+cd cf-worker
+npm install
+npm run deploy
+```
+
+`wrangler.toml`에서 버킷과 데이터베이스 이름을 수정한 뒤 위 명령을 실행하면 Pages에서 정적 프런트를 제공하고 Worker가 API를 처리하는 구성을 손쉽게 배포할 수 있습니다.

--- a/cf-worker/package.json
+++ b/cf-worker/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "visualmind-cf-worker",
+  "version": "0.1.0",
+  "type": "module",
+  "devDependencies": {
+    "typescript": "^5.4.0"
+  },
+  "dependencies": {
+    "hono": "^4.0.0",
+    "uuid": "^9.0.0"
+  },
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy"
+  }
+}

--- a/cf-worker/src/worker.ts
+++ b/cf-worker/src/worker.ts
@@ -1,0 +1,67 @@
+import { Hono } from 'hono';
+import { v4 as uuidv4 } from 'uuid';
+
+interface Env {
+  BUCKET: R2Bucket;
+  DB: D1Database;
+  UPSTAGE_KEY: string;
+}
+
+const app = new Hono<{ Bindings: Env }>();
+
+async function parseDocument(file: File, type: string, env: Env): Promise<string> {
+  const formData = new FormData();
+  formData.append('file', file);
+  formData.append('type', type);
+  const resp = await fetch('https://api.upstage.ai/v1/document/parse', {
+    method: 'POST',
+    headers: { 'Authorization': `Bearer ${env.UPSTAGE_KEY}` },
+    body: formData
+  });
+  if (!resp.ok) throw new Error('Parse failed');
+  const data = await resp.json();
+  return data.text as string;
+}
+
+async function buildMindMap(text: string, env: Env): Promise<any> {
+  const resp = await fetch('https://api.upstage.ai/v1/solar/chat', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${env.UPSTAGE_KEY}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ prompt: `Create a JSON mindmap: ${text}` })
+  });
+  if (!resp.ok) throw new Error('LLM failed');
+  return resp.json();
+}
+
+app.post('/api/upload', async c => {
+  const data = await c.req.formData();
+  const file = data.get('file') as File | null;
+  if (!file) return c.json({ error: 'file required' }, 400);
+  const key = `${Date.now()}-${file.name}`;
+  await c.env.BUCKET.put(key, await file.arrayBuffer(), { httpMetadata: { contentType: file.type } });
+  const text = await parseDocument(file, file.type, c.env);
+  const tree = await buildMindMap(text, c.env);
+  const id = uuidv4();
+  await c.env.DB.prepare(
+    'INSERT INTO maps (id, tree, text) VALUES (?, ?, ?)'
+  ).bind(id, JSON.stringify(tree), text).run();
+  return c.json({ id, tree, fileKey: key });
+});
+
+app.get('/api/maps/:id', async c => {
+  const id = c.req.param('id');
+  const { results } = await c.env.DB.prepare('SELECT * FROM maps WHERE id=?').bind(id).all();
+  if (!results.length) return c.json({ error: 'Not found' }, 404);
+  const row = results[0];
+  return c.json({ ...row, tree: JSON.parse(row.tree as string) });
+});
+
+app.get('/api/maps', async c => {
+  const { results } = await c.env.DB.prepare('SELECT id FROM maps ORDER BY rowid DESC LIMIT 100').all();
+  return c.json(results);
+});
+
+export default app;

--- a/cf-worker/wrangler.toml
+++ b/cf-worker/wrangler.toml
@@ -1,0 +1,14 @@
+name = "vmind-api"
+main = "src/worker.ts"
+compatibility_date = "2025-06-01"
+
+[[r2_buckets]]
+binding = "BUCKET"
+bucket_name = "vmind"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "vmind"
+
+[vars]
+UPSTAGE_KEY = "sk-..."


### PR DESCRIPTION
## Summary
- revert unwanted changes
- add Cloudflare Worker with D1 storage example
- document Worker deployment steps

## Testing
- `npm --workspace server test --silent`
- `npm --workspace client test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684ae3a2ac208325a838a9c2c6997442

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a Cloudflare Worker that enables file uploads, document parsing, and AI-generated mind map creation and retrieval via new API endpoints.
- **Documentation**
	- Added detailed deployment instructions and usage information for the Cloudflare Worker, including setup steps and configuration guidance in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->