### PR TITLE
Harmonize Upstage API key environment variable

### DIFF
--- a/cf-worker/src/worker.ts
+++ b/cf-worker/src/worker.ts
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 interface Env {
   BUCKET: R2Bucket;
   DB: D1Database;
-  UPSTAGE_KEY: string;
+  UPSTAGE_API_KEY: string;
 }
 
 const app = new Hono<{ Bindings: Env }>();
@@ -15,7 +15,7 @@ async function parseDocument(file: File, type: string, env: Env): Promise<string
   formData.append('type', type);
   const resp = await fetch('https://api.upstage.ai/v1/document/parse', {
     method: 'POST',
-    headers: { 'Authorization': `Bearer ${env.UPSTAGE_KEY}` },
+    headers: { 'Authorization': `Bearer ${env.UPSTAGE_API_KEY}` },
     body: formData
   });
   if (!resp.ok) throw new Error('Parse failed');
@@ -27,7 +27,7 @@ async function buildMindMap(text: string, env: Env): Promise<any> {
   const resp = await fetch('https://api.upstage.ai/v1/solar/chat', {
     method: 'POST',
     headers: {
-      'Authorization': `Bearer ${env.UPSTAGE_KEY}`,
+      'Authorization': `Bearer ${env.UPSTAGE_API_KEY}`,
       'Content-Type': 'application/json'
     },
     body: JSON.stringify({ prompt: `Create a JSON mindmap: ${text}` })

--- a/cf-worker/wrangler.toml
+++ b/cf-worker/wrangler.toml
@@ -11,4 +11,4 @@ binding = "DB"
 database_name = "vmind"
 
 [vars]
-UPSTAGE_KEY = "sk-..."
+UPSTAGE_API_KEY = "sk-..."


### PR DESCRIPTION
## Summary
- use `UPSTAGE_API_KEY` in CF worker configuration
- update Cloudflare worker code to read `UPSTAGE_API_KEY`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b71b746408325aec6e433921e2f12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the environment variable name for the Upstage API key to improve consistency. No changes to user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->