### PR TITLE
Implement review jobs queue

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -31,6 +31,15 @@ export function init() {
     due TEXT,
     UNIQUE(mapId, userId, path)
   )`);
+  db.exec(`CREATE TABLE IF NOT EXISTS review_jobs (
+    id TEXT PRIMARY KEY,
+    userId TEXT,
+    mapId TEXT,
+    path TEXT,
+    rating INTEGER,
+    status TEXT,
+    due TEXT
+  )`);
 }
 
 init();
@@ -57,5 +66,7 @@ export const insertCardStmt = db.prepare(`
 `);
 export const updateCardStmt = db.prepare('UPDATE fsrs SET stability = ?, difficulty = ?, due = ? WHERE id = ?');
 export const deleteCardsByMapStmt = db.prepare('DELETE FROM fsrs WHERE mapId = ? AND userId = ?');
+export const insertReviewJobStmt = db.prepare('INSERT INTO review_jobs (id, userId, mapId, path, rating, status) VALUES (?, ?, ?, ?, ?, ?);');
+export const updateReviewJobStmt = db.prepare('UPDATE review_jobs SET status = ?, due = ? WHERE id = ?');
 
 export default db;

--- a/server/reviewQueue.js
+++ b/server/reviewQueue.js
@@ -1,0 +1,36 @@
+import { Queue, Worker, QueueEvents } from 'bullmq';
+import { addFsrsForTree, getCard, schedule, updateCard } from './fsrs.js';
+import { insertReviewJobStmt, updateReviewJobStmt } from './db.js';
+
+const connection = process.env.REDIS_URL ? { connection: { url: process.env.REDIS_URL } } : null;
+
+export const reviewQueue = connection ? new Queue('review', connection) : null;
+export const reviewQueueEvents = connection ? new QueueEvents('review', connection) : null;
+
+export function enqueueReview(jobId, userId, mapId, path, rating) {
+  if (!reviewQueue) return null;
+  insertReviewJobStmt.run(jobId, userId, mapId, JSON.stringify(path), rating, 'queued');
+  return reviewQueue.add('review', { jobId, userId, mapId, path, rating });
+}
+
+export function startReviewWorker() {
+  if (!reviewQueue) return null;
+  const worker = new Worker('review', async job => {
+    const { jobId, userId, mapId, path, rating } = job.data;
+    let card = getCard(userId, mapId, path);
+    if (!card) {
+      addFsrsForTree(mapId, userId, {});
+      card = getCard(userId, mapId, path);
+    }
+    const { stability, difficulty, due } = schedule(card, rating);
+    updateCard(card.id, stability, difficulty, due);
+    updateReviewJobStmt.run('completed', due, jobId);
+    return { due };
+  }, connection);
+
+  worker.on('failed', (job, err) => {
+    console.error('Review job failed', job.id, err);
+    updateReviewJobStmt.run('failed', null, job.data.jobId);
+  });
+  return worker;
+}

--- a/server/test/review.test.js
+++ b/server/test/review.test.js
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import db, { insertReviewJobStmt } from '../db.js';
+import { v4 as uuidv4 } from 'uuid';
+
+describe('review schema', () => {
+  it('creates review_jobs table and allows insert', () => {
+    const id = uuidv4();
+    insertReviewJobStmt.run(id, 'u1', 'm1', '[]', 5, 'queued');
+    const row = db.prepare('SELECT * FROM review_jobs WHERE id = ?').get(id);
+    expect(row.userId).toBe('u1');
+    expect(row.status).toBe('queued');
+    db.prepare('DELETE FROM review_jobs WHERE id = ?').run(id);
+  });
+});

--- a/server/worker.js
+++ b/server/worker.js
@@ -1,2 +1,5 @@
 import { startWorker } from './queue.js';
+import { startReviewWorker } from './reviewQueue.js';
+
 startWorker();
+startReviewWorker();


### PR DESCRIPTION
## Summary
- create `review_jobs` table
- add BullMQ review queue and worker
- start review worker with existing worker script
- test review table inserts with cleanup

## Testing
- `npm --prefix server test --silent`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684be10f25808325a5ed387a7d34f7be

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a review job queue system to manage and process review tasks.
  - Added support for scheduling and updating review jobs with status tracking.
- **Tests**
  - Implemented tests to verify review job creation and database integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->